### PR TITLE
Removing Ericsson from MAINTAINERS.MD

### DIFF
--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -6,4 +6,3 @@
 | China Mobile  | Hanbai Wang     | HanbaiWang |
 | Huawei        | Kai Zhang       | Kai-hw |
 | Huawei        | Shuting Qing    | ShutingQing |
-| Ericsson      | Thorsten Lohmar | tlohmar |


### PR DESCRIPTION
Ericsson has started focusing on the Dedicated Networks API and instead of Network Slice Booking.

#### What type of PR is this?

Add one of the following kinds:
* subproject management


#### What this PR does / why we need it:
This PR removes Ericsson from the Maintainer list.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
