### PR TITLE
Split NetworkSliceBooking422-SERVICE_NOT_APPLICABLE into SERVICE_AREA_NOT_SUPPORTED and RESOURCES_INSUFFICIENT

### DIFF
--- a/code/API_definitions/network-slice-booking.yaml
+++ b/code/API_definitions/network-slice-booking.yaml
@@ -70,8 +70,9 @@ paths:
         Create a new network slice with the expected service time, service area, and QoS profile.
 
         NOTES:
-        - If expected network slice resources are not available, the API consumer will receive an error response with code `422 - NETWORK_SLICE_BOOKING.RESOURCES_NOT_APPLICABLE`.
         - If newtwork slice creation is successful, the API consumer will receive a response with code `201 - Created` and a slice ID.
+        - If requested service area is not supported, the API consumer will receive a response with code `422 - NETWORK_SLICE_BOOKING.SERVICEAREA_NOT_SUPPORTED`.
+        - If the left resources are not sufficient for the requested slice resources, the API consumer will receive a response with code `422 - NETWORK_SLICE_BOOKING.RESOURCES_INSUFFICIENT`.
       operationId: createSlice
       security:
         - openId:
@@ -872,14 +873,21 @@ components:
                       - 422
                   code:
                     enum:
-                      - NETWORK_SLICE_BOOKING.RESOURCES_NOT_APPLICABLE
+                      - NETWORK_SLICE_BOOKING.SERVICEAREA_NOT_SUPPORTED
+                      - NETWORK_SLICE_BOOKING.RESOURCES_INSUFFICIENT
           examples:
-            NETWORK_SLICE_BOOKING_422_RESOURCES_NOT_APPLICABLE:
-              description: Request cannot be processed due to business logic validation failure, e.g. service area is not supported or resources are insufficient
+            NETWORK_SLICE_BOOKING_422_SERVICE_AREA_NOT_SUPPORTED:
+              description: Business logic exception use when the requested service area is not supported
               value:
                 status: 422
-                code: NETWORK_SLICE_BOOKING.RESOURCES_NOT_APPLICABLE
-                message: The request resources are not applicable for slice creation.
+                code: NETWORK_SLICE_BOOKING.SERVICEAREA_NOT_SUPPORTED
+                message: The requested service area is not supported.
+            NETWORK_SLICE_BOOKING_422_RESOURCES_INSUFFICIENT:
+              description: Business logic exception use when the left resources are not sufficient for the requested slice resources
+              value:
+                status: 422
+                code: NETWORK_SLICE_BOOKING.RESOURCES_INSUFFICIENT
+                message: The left resources are not sufficient for the requested slice resources.
     Generic429:
       description: Quota Exceed or Too Many Requests
       headers:

--- a/code/Test_definitions/network-slice-booking-createSession.feature
+++ b/code/Test_definitions/network-slice-booking-createSession.feature
@@ -91,10 +91,21 @@ Feature: CAMARA Network Slice Booking API vwip - Operation createSlice
     And the response header "x-correlator" has same value as the request header "x-correlator"
     And the response header "Content-Type" is "application/json"
     And the response property "$.status" is 422
-    And the response property "$.code" is "NETWORK_SLICE_BOOKING.RESOURCES_NOT_APPLICABLE"
-    And the response property "$.message" is "The request resources are not applicable for slice creation."
+    And the response property "$.code" is "NETWORK_SLICE_BOOKING.SERVICEAREA_NOT_SUPPORTED"
+    And the response property "$.message" is "The requested service area is not supported."
 
-  @network_slice_booking_createSlice_08_quota_exceeded_scenario
+  @network_slice_booking_createSlice_08_resource_insufficient_scenario
+  Scenario: Common validations for fail scenario of the left resources not sufficient for the requested slice resources
+    Given the configuration of information of network slicing that exceeds slice resources
+    When the request "createSlice" is sent
+    Then the response status code is 422
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 422
+    And the response property "$.code" is "NETWORK_SLICE_BOOKING.RESOURCES_INSUFFICIENT"
+    And the response property "$.message" is "The left resources are not sufficient for the requested slice resources."
+
+  @network_slice_booking_createSlice_09_quota_exceeded_scenario
   Scenario: Error response for quota exceeded
     Given the right request body property argument
     When the request "createSlice" is sent
@@ -105,7 +116,7 @@ Feature: CAMARA Network Slice Booking API vwip - Operation createSlice
     And the response property "$.code" is "QUOTA_EXCEEDED"
     And the response property "$.message" is "Out of resource quota."
 
-  @network_slice_booking_createSlice_09_too_many_requests_scenario
+  @network_slice_booking_createSlice_10_too_many_requests_scenario
   Scenario: Error response for too many requests
     Given the right request body property argument
     When the request "createSlice" is sent


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* enhancement/feature



#### What this PR does / why we need it:

There are several reasons listed in the example which worth having their own 422 error : service area is not supported, resources are insufficient - for better problem understand, split `NetworkSliceBooking422-SERVICE_NOT_APPLICABLE` into `SERVICE_AREA_NOT_SUPPORTED` and `RESOURCES_INSUFFICIENT`.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #81 

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```


