### PR TITLE
Reset API and test code version information in main branch to wip

### DIFF
--- a/code/API_definitions/network-slice-assignment.yaml
+++ b/code/API_definitions/network-slice-assignment.yaml
@@ -48,7 +48,7 @@ info:
 
     As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
 
-  version: 0.1.0-rc.1
+  version: wip
   x-camara-commonalities: "0.7"
   license:
     name: Apache 2.0
@@ -57,7 +57,7 @@ externalDocs:
   description: Project documentation at CAMARA
   url: https://github.com/camaraproject/NetworkSliceBooking
 servers:
-  - url: "{apiRoot}/network-slice-assignment/v0.1rc1"
+  - url: "{apiRoot}/network-slice-assignment/vwip"
     variables:
       apiRoot:
         default: http://localhost:9100

--- a/code/API_definitions/network-slice-booking.yaml
+++ b/code/API_definitions/network-slice-booking.yaml
@@ -3,7 +3,7 @@ info:
   title: Network Slice Booking
   description: |
     The Network Slice Booking (NSB) API provides programmable interface for developers to reserve a slice resource of a selected area within a period, and manage device access control as needed.
-    For specific details, please refer to [Network Slice Booking API Design.md](https://github.com/camaraproject/NetworkSliceBooking/blob/r1.2/documentation/API_documentation/Network_Slice_Booking_API_Design.md).
+    For specific details, please refer to [Network Slice Booking API Design.md](https://github.com/camaraproject/NetworkSliceBooking/blob/main/documentation/API_documentation/Network_Slice_Booking_API_Design.md).
 
     # Introduction
 
@@ -43,7 +43,7 @@ info:
 
     As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
 
-  version: 0.2.0-rc.1
+  version: wip
   x-camara-commonalities: "0.7"
   license:
     name: Apache 2.0
@@ -52,7 +52,7 @@ externalDocs:
   description: Project documentation at CAMARA
   url: https://github.com/camaraproject/NetworkSliceBooking
 servers:
-  - url: "{apiRoot}/network-slice-booking/v0.2rc1"
+  - url: "{apiRoot}/network-slice-booking/vwip"
     variables:
       apiRoot:
         default: http://localhost:9100

--- a/code/Test_definitions/network-slice-assignment-assignDevice.feature
+++ b/code/Test_definitions/network-slice-assignment-assignDevice.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Network Slice Assignment API v0.1.0-rc.1 - Operation assignDevice
+Feature: CAMARA Network Slice Assignment API vwip - Operation assignDevice
 
     # Input to be provided by the implementation to the tester
     #
@@ -7,11 +7,11 @@ Feature: CAMARA Network Slice Assignment API v0.1.0-rc.1 - Operation assignDevic
 	# * List of device identifier types which are not supported, among: phoneNumber, ipv4Address, ipv6Address.
 	# * For this version, CAMARA does not allow the use of networkAccessIdentifier, so it is considered by default as not supported.
 	#
-    # References to OAS spec schemas refer to schemas specified in network-slice-assignment.yaml, version 0.1.0-rc.1
+    # References to OAS spec schemas refer to schemas specified in network-slice-assignment.yaml, version wip
 
   Background: Common assignDevice setup
     Given an environment at "apiRoot"
-    And the resource "/network-slice-assignment/v0.1rc1/slices/{sliceId}/devices"
+    And the resource "/network-slice-assignment/vwip/slices/{sliceId}/devices"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/network-slice-assignment-getDevices.feature
+++ b/code/Test_definitions/network-slice-assignment-getDevices.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Network Slice Assignment API v0.1.0-rc.1 - Operation getDevices
+Feature: CAMARA Network Slice Assignment API vwip - Operation getDevices
 
 	# Get information about devices assigned to an existing network slice.
 
@@ -14,11 +14,11 @@ Feature: CAMARA Network Slice Assignment API v0.1.0-rc.1 - Operation getDevices
 	# * List of device identifier types which are not supported, among: phoneNumber, ipv4Address, ipv6Address.
 	# * For this version, CAMARA does not allow the use of networkAccessIdentifier, so it is considered by default as not supported.
 	#
-    # References to OAS spec schemas refer to schemas specified in network-slice-assignment.yaml, version 0.1.0-rc.1
+    # References to OAS spec schemas refer to schemas specified in network-slice-assignment.yaml, version wip
 
   Background: Common getDevices setup
     Given an environment at "apiRoot"
-    And the resource "/network-slice-assignment/v0.1rc1/slices/{sliceId}/devices"
+    And the resource "/network-slice-assignment/vwip/slices/{sliceId}/devices"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/network-slice-assignment-releaseDevice.feature
+++ b/code/Test_definitions/network-slice-assignment-releaseDevice.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Network Slice Assignment API v0.1.0-rc.1 - Operation releaseDevice
+Feature: CAMARA Network Slice Assignment API vwip - Operation releaseDevice
 
     # Input to be provided by the implementation to the tester
     #
@@ -9,11 +9,11 @@ Feature: CAMARA Network Slice Assignment API v0.1.0-rc.1 - Operation releaseDevi
 	# * The DeviceAssignmentInfo of an existing Slice assignment
 	# * The DeviceAssignmentInfo of an existing Slice assignment with status "AVAILABLE", and with provided values for "sink" and "sinkCredential"
 	#
-    # References to OAS spec schemas refer to schemas specified in network-slice-assignment.yaml, version 0.1.0-rc.1
+    # References to OAS spec schemas refer to schemas specified in network-slice-assignment.yaml, version wip
 
   Background: Common releaseDevice setup
     Given an environment at "apiRoot"
-    And the resource "/network-slice-assignment/v0.1rc1/slices/{sliceId}/release"
+    And the resource "/network-slice-assignment/vwip/slices/{sliceId}/release"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/network-slice-assignment-retrieveSlicesByDevice.feature
+++ b/code/Test_definitions/network-slice-assignment-retrieveSlicesByDevice.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Network Slice Assignment API v0.1.0-rc.1 - Operation retrieveSlicesByDevice
+Feature: CAMARA Network Slice Assignment API vwip - Operation retrieveSlicesByDevice
 
 	# Retrieve the list of network slices to which a device is assigned.
 
@@ -14,11 +14,11 @@ Feature: CAMARA Network Slice Assignment API v0.1.0-rc.1 - Operation retrieveSli
 	# * List of device identifier types which are not supported, among: phoneNumber, ipv4Address, ipv6Address.
 	# * For this version, CAMARA does not allow the use of networkAccessIdentifier, so it is considered by default as not supported.
 	#
-    # References to OAS spec schemas refer to schemas specified in network-slice-assignment.yaml, version 0.1.0-rc.1
+    # References to OAS spec schemas refer to schemas specified in network-slice-assignment.yaml, version wip
 
   Background: Common retrieveSlicesByDevice setup
     Given an environment at "apiRoot"
-    And the resource "/network-slice-assignment/v0.1rc1/retrieve-slices"
+    And the resource "/network-slice-assignment/vwip/retrieve-slices"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/network-slice-booking-createSlice.feature
+++ b/code/Test_definitions/network-slice-booking-createSlice.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Network Slice Booking API v0.2.0-rc.1 - Operation createSlice
+Feature: CAMARA Network Slice Booking API vwip - Operation createSlice
 
     # Input to be provided by the implementation to the tester
     #
@@ -14,11 +14,11 @@ Feature: CAMARA Network Slice Booking API v0.2.0-rc.1 - Operation createSlice
     # * An Area outside the supported area
     # * A combination of request parameters including service area, start time, and end time, configuration information of network slicing
     #
-    # References to OAS spec schemas refer to schemas specified in network-slice-booking.yaml, version 0.2.0-rc.1
+    # References to OAS spec schemas refer to schemas specified in network-slice-booking.yaml, version wip
 
   Background: Common createSlice setup
     Given an environment at "apiRoot"
-    And the resource "/network-slice-booking/v0.2rc1/slices"
+    And the resource "/network-slice-booking/vwip/slices"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/network-slice-booking-deleteSlice.feature
+++ b/code/Test_definitions/network-slice-booking-deleteSlice.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Network Slice Booking API v0.2.0-rc.1 - Operation deleteSlice
+Feature: CAMARA Network Slice Booking API vwip - Operation deleteSlice
 
     # Input to be provided by the implementation to the tester
     #
@@ -7,11 +7,11 @@ Feature: CAMARA Network Slice Booking API v0.2.0-rc.1 - Operation deleteSlice
     #
     # Testing assets:
     # * The sliceId of an existing slice.
-    # * References to OAS spec schemas refer to schemas specified in network-slice-booking.yaml, version 0.2.0-rc.1
+    # * References to OAS spec schemas refer to schemas specified in network-slice-booking.yaml, version wip
 
   Background: Common deleteSlice setup
     Given an environment at "apiRoot"
-    And the resource "/network-slice-booking/v0.2rc1/slices/{sliceId}"
+    And the resource "/network-slice-booking/vwip/slices/{sliceId}"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/network-slice-booking-getSlice.feature
+++ b/code/Test_definitions/network-slice-booking-getSlice.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Network Slice Booking API v0.2.0-rc.1 - Operation getSlice
+Feature: CAMARA Network Slice Booking API vwip - Operation getSlice
 
     # Input to be provided by the implementation to the tester
     #
@@ -7,11 +7,11 @@ Feature: CAMARA Network Slice Booking API v0.2.0-rc.1 - Operation getSlice
     #
     # Testing assets:
     # * The sliceId of an existing slice.
-    # * References to OAS spec schemas refer to schemas specified in network-slice-booking.yaml, version 0.2.0-rc.1
+    # * References to OAS spec schemas refer to schemas specified in network-slice-booking.yaml, version wip
 
   Background: Common getSlice setup
     Given an environment at "apiRoot"
-    And the resource "/network-slice-booking/v0.2rc1/slices/{sliceId}"
+    And the resource "/network-slice-booking/vwip/slices/{sliceId}"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"


### PR DESCRIPTION
#### What type of PR is this?

* repository management

#### What this PR does / why we need it:

Reset API and test code version information in the main branch back to work-in-progress state.

- Set `info.version` to `wip` in both OpenAPI definitions
- Switch the server URLs to `vwip`
- Update affected feature titles, schema-version comments, and resource URLs to `vwip`
- Reset the embedded Network Slice Booking design document link to `main`

#### Which issue(s) this PR fixes:

Fixes #102

#### Special notes for reviewers:

- README and CHANGELOG release links were intentionally left unchanged

#### Changelog input

```
release-note
```
