### PR TITLE
Modify r2.2 release plan from public back to release-candidate

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -20,7 +20,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: public-release
+  target_release_type: pre-release-rc
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -34,14 +34,14 @@ dependencies:
 apis:
   - api_name: network-slice-booking
     target_api_version: 0.2.0
-    target_api_status: public
+    target_api_status: rc
     main_contacts:
       - chinaunicomyangfan
       - DanXu-ChinaTelecom
       - Kai-hw
   - api_name: network-slice-assignment
     target_api_version: 0.1.0
-    target_api_status: public
+    target_api_status: rc
     main_contacts:
       - chinaunicomyangfan
       - DanXu-ChinaTelecom


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* subproject management



#### What this PR does / why we need it:
As mentioned in #112 
> r4.2 is the second release candidate of Commonalities, therefore it can't already yet be used to create a public release for Spring26. Please change the release-plan.yaml in the meantime back to rc. You can create a second release candidate release to get a review and be sure that everything fits for the later public release (when Commonalities r4.3 is available).

Modify r2.2 release plan from public back to release-candidate

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

