### PR TITLE
Update release-plan to public release

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -16,16 +16,16 @@ repository:
   # Initialized to the latest release; update when planning the next release.
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r2.2
+  target_release_tag: r2.3
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-rc
+  target_release_type: public-release
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r4.2
+  commonalities_release: r4.3
   identity_consent_management_release: r4.2
 
 # APIs in this repository
@@ -34,14 +34,14 @@ dependencies:
 apis:
   - api_name: network-slice-booking
     target_api_version: 0.2.0
-    target_api_status: rc
+    target_api_status: public
     main_contacts:
       - chinaunicomyangfan
       - DanXu-ChinaTelecom
       - Kai-hw
   - api_name: network-slice-assignment
     target_api_version: 0.1.0
-    target_api_status: rc
+    target_api_status: public
     main_contacts:
       - chinaunicomyangfan
       - DanXu-ChinaTelecom


### PR DESCRIPTION
#### What type of PR is this?

subproject management

#### What this PR does / why we need it:

Updates the release-plan.yaml to prepare for public release r2.3:
- Update target release tag from r2.2 to r2.3
- Change release type from pre-release-rc to public-release
- Update Commonalities dependency from r4.2 to r4.3
- Update API status from rc to public for network-slice-booking (v0.2.0) and network-slice-assignment (v0.1.0)

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

This prepares the repository for the upcoming public release.

#### Changelog input

```
release-note
Update release-plan for public release r2.3
```

#### Additional documentation

```
docs
```