### PR TITLE
Add missing changelog entries for r2.3 release

### DIFF
--- a/CHANGELOG/CHANGELOG-r2.md
+++ b/CHANGELOG/CHANGELOG-r2.md
@@ -78,9 +78,13 @@ The API definition(s) are based on
 ### Added
 
 * Align with Commonalities r4.3 - Add mandatory templates and fix schemas in [#130](https://github.com/camaraproject/NetworkSliceBooking/pull/130)
+* Add maxLength requirement applies to all string properties in [#108](https://github.com/camaraproject/NetworkSliceBooking/pull/108)
 
 ### Changed
 
+* Rename the term "session" to "slice" for clarity in [#87](https://github.com/camaraproject/NetworkSliceBooking/pull/87)
+* Split 422 SERVICE_NOT_APPLICABLE error into SERVICE_AREA_NOT_SUPPORTED and RESOURCES_INSUFFICIENT for better problem understanding in [#92](https://github.com/camaraproject/NetworkSliceBooking/pull/92)
+* Change the callback request body schema from CloudEvent to ApiNotificationEvent aligning with Commonalities r4.2 in [#108](https://github.com/camaraproject/NetworkSliceBooking/pull/108)
 * Update API definitions with corrected defaults and schema constraints aligning with Commonalities r4.2 in [#116](https://github.com/camaraproject/NetworkSliceBooking/pull/116)
 * Replace inline CloudEvent + sink-credential schemas and inline area / geometry schemas with $refs into CAMARA_event_common.yaml in [#120](https://github.com/camaraproject/NetworkSliceBooking/pull/120)
 
@@ -99,11 +103,16 @@ The API definition(s) are based on
 
 ### Added
 
+* Initial public definition of the Network Slice Assignment API to provide users the method to subscribe a network slice service in [#87](https://github.com/camaraproject/NetworkSliceBooking/pull/87)
+* Modify network-slice-assignment API Path and Feature Files in [#96](https://github.com/camaraproject/NetworkSliceBooking/pull/96)
+* Add maxLength requirement applies to all string properties in [#108](https://github.com/camaraproject/NetworkSliceBooking/pull/108)
+* Add maxItems requirement for array properties, maximum requirement for object properties and description for all properties in [#116](https://github.com/camaraproject/NetworkSliceBooking/pull/116)
 * Align with Commonalities r4.3 - Add mandatory templates and fix schemas in [#130](https://github.com/camaraproject/NetworkSliceBooking/pull/130)
 
 ### Changed
 
-* Update API definitions with corrected defaults and schema constraints aligning with Commonalities r4.2 in [#116](https://github.com/camaraproject/NetworkSliceBooking/pull/116)
+* Change the callback request body schema from CloudEvent to ApiNotificationEvent aligning with Commonalities r4.2 in [#108](https://github.com/camaraproject/NetworkSliceBooking/pull/108)
+* Modify the apiRoot path to `http://localhost:9091` in [#116](https://github.com/camaraproject/NetworkSliceBooking/pull/116)
 * Replace inline CloudEvent + sink-credential schemas and inline area / geometry schemas with $refs into CAMARA_event_common.yaml in [#120](https://github.com/camaraproject/NetworkSliceBooking/pull/120)
 
 ### Removed


### PR DESCRIPTION
﻿#### What type of PR is this?

subproject management

#### What this PR does / why we need it:

Completes the CHANGELOG-r2.md for the r2.3 release with actual release details:
- Updates version descriptions for network-slice-booking 0.2.0 and network-slice-assignment 0.1.0
- Fills in Added/Changed/Removed sections with PR references (#116, #120, #130)
- Removes placeholder text "_To be filled during release review_"

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

This is a documentation-only change to finalize the CHANGELOG for the r2.3 release. No code changes.

#### Changelog input

``
release-note
Update CHANGELOG-r2.md with release details for r2.3
``

#### Additional documentation 

``
docs
``
